### PR TITLE
feat(mockups): Add home page

### DIFF
--- a/mockups/home.html
+++ b/mockups/home.html
@@ -1,0 +1,343 @@
+<html>
+  <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
+    />
+
+    <title>Stitch Design</title>
+    <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  </head>
+  <body>
+    <div
+      class="relative flex size-full min-h-screen flex-col bg-[#101a23] dark group/design-root overflow-x-hidden"
+      style="font-family: Inter, &quot;Noto Sans&quot;, sans-serif"
+    >
+      <div class="layout-container flex h-full grow flex-col">
+        <header
+          class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#223649] px-10 py-3"
+        >
+          <div class="flex items-center gap-4 text-white">
+            <div class="size-4">
+              <svg
+                viewBox="0 0 48 48"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z"
+                  fill="currentColor"
+                ></path>
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </div>
+            <h2
+              class="text-white text-lg font-bold leading-tight tracking-[-0.015em]"
+            >
+              Chitchatter Pro
+            </h2>
+          </div>
+          <div class="flex flex-1 justify-end gap-8">
+            <div
+              class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+              style="
+                background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuC7W2-cJg4o_oyLoLZ7H3cDI2i7hSwnFETBlmixGUrENYz_Q65irRlO3cvP8_YGPvhmBvvB4HwK0m_4TY3C69nAOciez1ybzVOjccIpg48zqzmIAgOv-MUn1W3G6Ytijn_fx3xTnRFp6X_AuNzYwVUBvC7uOdP7buChklJsFFs4lSZ9QAjAA_C3n87jZKFCne-WdqmdOZq084No930X2MyGenWOJg3GvzEM5Ee-CFaIk8XGkYkOierWb-0tOKI6HRQuUIFHDoMlQiU&quot;);
+              "
+            ></div>
+          </div>
+        </header>
+        <div class="px-40 flex flex-1 justify-center py-5">
+          <div
+            class="layout-content-container flex flex-col max-w-[960px] flex-1"
+          >
+            <div class="flex flex-wrap justify-between gap-3 p-4">
+              <div class="flex min-w-72 flex-col gap-3">
+                <p
+                  class="text-white tracking-light text-[32px] font-bold leading-tight"
+                >
+                  Dashboard
+                </p>
+                <p class="text-[#90aecb] text-sm font-normal leading-normal">
+                  Overview of Chitchatter Pro usage and activity
+                </p>
+              </div>
+            </div>
+            <h2
+              class="text-white text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
+            >
+              Instances (45)
+            </h2>
+            <div class="px-4 py-3 @container">
+              <div
+                class="flex overflow-hidden rounded-lg border border-[#314d68] bg-[#101a23]"
+              >
+                <table class="flex-1">
+                  <thead>
+                    <tr class="bg-[#182734]">
+                      <th
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 px-4 py-3 text-left text-white w-14 text-sm font-medium leading-normal"
+                      ></th>
+                      <th
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 px-4 py-3 text-left text-white w-[400px] text-sm font-medium leading-normal"
+                      >
+                        Subdomain
+                      </th>
+                      <th
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 px-4 py-3 text-left text-white w-[400px] text-sm font-medium leading-normal"
+                      >
+                        Created
+                      </th>
+                      <th
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 px-4 py-3 text-left text-white w-[400px] text-sm font-medium leading-normal"
+                      >
+                        Relay usage (15/25GB)
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="border-t border-t-[#314d68]">
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 h-[72px] px-4 py-2 w-14 text-sm font-normal leading-normal"
+                      >
+                        <div
+                          class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-10"
+                          style="
+                            background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuAsVLLCae4xaTEuKtRwFtj39KIyH42xsCxAaG_zl0E5L0YXTqkByj8Y8esJbqzgb_chzDUAdjxH5RmXISQRiITsFuRovcno6CAePL1yuyewl4zz_D81RmpFvgKaHMwfz83Gz4Mal-T4DEp603dbehkRwvzHVHkl8OCUmIK5eGt0yT_K6AyBkS2nGYP-vTQckyDOQ6CN884S6lzihHcnIS4Cavp56R9JdKWMV_AJ2j6t7XqNrkUTMrrcDOBLb8QdLmAqmySo4pyt5-U&quot;);
+                          "
+                        ></div>
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 h-[72px] px-4 py-2 w-[400px] text-white text-sm font-normal leading-normal"
+                      >
+                        secure.chitchatter.pro
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2023-09-20 10:00 AM
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        3 GB
+                      </td>
+                    </tr>
+                    <tr class="border-t border-t-[#314d68]">
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 h-[72px] px-4 py-2 w-14 text-sm font-normal leading-normal"
+                      >
+                        <div
+                          class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-10"
+                          style="
+                            background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuAsVLLCae4xaTEuKtRwFtj39KIyH42xsCxAaG_zl0E5L0YXTqkByj8Y8esJbqzgb_chzDUAdjxH5RmXISQRiITsFuRovcno6CAePL1yuyewl4zz_D81RmpFvgKaHMwfz83Gz4Mal-T4DEp603dbehkRwvzHVHkl8OCUmIK5eGt0yT_K6AyBkS2nGYP-vTQckyDOQ6CN884S6lzihHcnIS4Cavp56R9JdKWMV_AJ2j6t7XqNrkUTMrrcDOBLb8QdLmAqmySo4pyt5-U&quot;);
+                          "
+                        ></div>
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 h-[72px] px-4 py-2 w-[400px] text-white text-sm font-normal leading-normal"
+                      >
+                        private.chitchatter.pro
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2023-09-20 09:30 AM
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2 GB
+                      </td>
+                    </tr>
+                    <tr class="border-t border-t-[#314d68]">
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 h-[72px] px-4 py-2 w-14 text-sm font-normal leading-normal"
+                      >
+                        <div
+                          class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-10"
+                          style="
+                            background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuAsVLLCae4xaTEuKtRwFtj39KIyH42xsCxAaG_zl0E5L0YXTqkByj8Y8esJbqzgb_chzDUAdjxH5RmXISQRiITsFuRovcno6CAePL1yuyewl4zz_D81RmpFvgKaHMwfz83Gz4Mal-T4DEp603dbehkRwvzHVHkl8OCUmIK5eGt0yT_K6AyBkS2nGYP-vTQckyDOQ6CN884S6lzihHcnIS4Cavp56R9JdKWMV_AJ2j6t7XqNrkUTMrrcDOBLb8QdLmAqmySo4pyt5-U&quot;);
+                          "
+                        ></div>
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 h-[72px] px-4 py-2 w-[400px] text-white text-sm font-normal leading-normal"
+                      >
+                        confidential.chitchatter.pro
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2023-09-20 09:00 AM
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        4 GB
+                      </td>
+                    </tr>
+                    <tr class="border-t border-t-[#314d68]">
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 h-[72px] px-4 py-2 w-14 text-sm font-normal leading-normal"
+                      >
+                        <div
+                          class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-10"
+                          style="
+                            background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuAsVLLCae4xaTEuKtRwFtj39KIyH42xsCxAaG_zl0E5L0YXTqkByj8Y8esJbqzgb_chzDUAdjxH5RmXISQRiITsFuRovcno6CAePL1yuyewl4zz_D81RmpFvgKaHMwfz83Gz4Mal-T4DEp603dbehkRwvzHVHkl8OCUmIK5eGt0yT_K6AyBkS2nGYP-vTQckyDOQ6CN884S6lzihHcnIS4Cavp56R9JdKWMV_AJ2j6t7XqNrkUTMrrcDOBLb8QdLmAqmySo4pyt5-U&quot;);
+                          "
+                        ></div>
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 h-[72px] px-4 py-2 w-[400px] text-white text-sm font-normal leading-normal"
+                      >
+                        secret.chitchatter.pro
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2023-09-20 08:30 AM
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        1 GB
+                      </td>
+                    </tr>
+                    <tr class="border-t border-t-[#314d68]">
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 h-[72px] px-4 py-2 w-14 text-sm font-normal leading-normal"
+                      >
+                        <div
+                          class="bg-center bg-no-repeat aspect-square bg-cover rounded-full w-10"
+                          style="
+                            background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuAsVLLCae4xaTEuKtRwFtj39KIyH42xsCxAaG_zl0E5L0YXTqkByj8Y8esJbqzgb_chzDUAdjxH5RmXISQRiITsFuRovcno6CAePL1yuyewl4zz_D81RmpFvgKaHMwfz83Gz4Mal-T4DEp603dbehkRwvzHVHkl8OCUmIK5eGt0yT_K6AyBkS2nGYP-vTQckyDOQ6CN884S6lzihHcnIS4Cavp56R9JdKWMV_AJ2j6t7XqNrkUTMrrcDOBLb8QdLmAqmySo4pyt5-U&quot;);
+                          "
+                        ></div>
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 h-[72px] px-4 py-2 w-[400px] text-white text-sm font-normal leading-normal"
+                      >
+                        hidden.chitchatter.pro
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        2023-09-20 08:00 AM
+                      </td>
+                      <td
+                        class="table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 h-[72px] px-4 py-2 w-[400px] text-[#90aecb] text-sm font-normal leading-normal"
+                      >
+                        5 GB
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <style>
+                @container (max-width:56px) {
+                  .table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-56 {
+                    display: none;
+                  }
+                }
+                @container (max-width:176px) {
+                  .table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-176 {
+                    display: none;
+                  }
+                }
+                @container (max-width:296px) {
+                  .table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-296 {
+                    display: none;
+                  }
+                }
+                @container (max-width:416px) {
+                  .table-2c345f07-3a03-4d7f-9ed6-67bba435ab5c-column-416 {
+                    display: none;
+                  }
+                }
+              </style>
+            </div>
+            <div class="flex items-center justify-center p-4">
+              <a href="#" class="flex size-10 items-center justify-center">
+                <div
+                  class="text-white"
+                  data-icon="CaretLeft"
+                  data-size="18px"
+                  data-weight="regular"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18px"
+                    height="18px"
+                    fill="currentColor"
+                    viewBox="0 0 256 256"
+                  >
+                    <path
+                      d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"
+                    ></path>
+                  </svg>
+                </div>
+              </a>
+              <a
+                class="text-sm font-bold leading-normal tracking-[0.015em] flex size-10 items-center justify-center text-white rounded-full bg-[#223649]"
+                href="#"
+                >1</a
+              >
+              <a
+                class="text-sm font-normal leading-normal flex size-10 items-center justify-center text-white rounded-full"
+                href="#"
+                >2</a
+              >
+              <a
+                class="text-sm font-normal leading-normal flex size-10 items-center justify-center text-white rounded-full"
+                href="#"
+                >3</a
+              >
+              <a
+                class="text-sm font-normal leading-normal flex size-10 items-center justify-center text-white rounded-full"
+                href="#"
+                >4</a
+              >
+              <a
+                class="text-sm font-normal leading-normal flex size-10 items-center justify-center text-white rounded-full"
+                href="#"
+                >5</a
+              >
+              <a href="#" class="flex size-10 items-center justify-center">
+                <div
+                  class="text-white"
+                  data-icon="CaretRight"
+                  data-size="18px"
+                  data-weight="regular"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18px"
+                    height="18px"
+                    fill="currentColor"
+                    viewBox="0 0 256 256"
+                  >
+                    <path
+                      d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                    ></path>
+                  </svg>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a (rough) mockup for what Chitchatter Pro's Home page could look like.

<img width="2182" height="1656" alt="Screenshot of Chitchatter Pro Home screen mockup" src="https://github.com/user-attachments/assets/de297736-35a6-4029-aac6-aea0099203b3" />
